### PR TITLE
Fix angle normalization mirroring error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./App.css";
 import CircleDial from "./components/CircleDial";
 

--- a/src/components/circle-dial/utils/angles.ts
+++ b/src/components/circle-dial/utils/angles.ts
@@ -12,7 +12,11 @@ export function angularDistance(a: number, b: number): number {
 
 export function normalizeAngle180(a: number): number {
   const w = wrap360(a);
-  return w > 180 ? w - 180 : w;
+  // Fold any angle into the [0, 180] range by mirroring values above 180
+  // around the 180° axis. Previously this subtracted 180 which produced
+  // incorrect results (e.g. 200° -> 20°). The correct mirror is 360 - w
+  // so 200° becomes 160° and 181° becomes 179°.
+  return w > 180 ? 360 - w : w;
 }
 
 export function normalizeSigned180(a: number): number {


### PR DESCRIPTION
## Summary
- fix normalizeAngle180 to mirror angles over 180° correctly
- remove unused React import

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895fb940bf0832babddd007ad30ad52