### PR TITLE
Add voice-reactive canvas animation page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "motion": "^12.23.12",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.29.0",
+    "three": "^0.157.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,13 @@
-import React from "react";
-import "./App.css";
-import CircleDial from "./components/CircleDial";
+import { Routes, Route, Navigate } from "react-router-dom";
+import Circle from "./pages/Circle";
+import Voice from "./pages/Voice";
 
-function App() {
+export default function App() {
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        padding: 16,
-      }}
-    >
-      <CircleDial autoPlay />
-    </div>
+    <Routes>
+      <Route path="/" element={<Navigate to="/circle" />} />
+      <Route path="/circle" element={<Circle />} />
+      <Route path="/voice" element={<Voice />} />
+    </Routes>
   );
 }
-
-export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/src/pages/Circle.tsx
+++ b/src/pages/Circle.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import CircleDial from "../components/CircleDial";
+
+export default function Circle() {
+  return (
+    <>
+      <div style={{ position: "absolute", top: 16, right: 16 }}>
+        <Link to="/voice" style={{ color: "#646cff" }}>
+          Voice Avatar
+        </Link>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          padding: 16,
+        }}
+      >
+        <CircleDial autoPlay />
+      </div>
+    </>
+  );
+}

--- a/src/pages/Voice.tsx
+++ b/src/pages/Voice.tsx
@@ -1,0 +1,99 @@
+import { useRef, useEffect } from "react";
+import { Link } from "react-router-dom";
+import * as THREE from "three";
+
+export default function Voice() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setSize(200, 200);
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+    camera.position.z = 2.5;
+
+    const geometry = new THREE.SphereGeometry(0.8, 64, 64);
+    const material = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: { value: 0 },
+        uLevel: { value: 0 },
+      },
+      vertexShader: `
+        uniform float uTime;
+        uniform float uLevel;
+        varying vec3 vNormal;
+        void main() {
+          vec3 pos = position + normal * uLevel * 0.4 * sin(uTime + position.y * 4.0);
+          vNormal = normal;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+        }
+      `,
+      fragmentShader: `
+        uniform float uLevel;
+        varying vec3 vNormal;
+        void main() {
+          float intensity = dot(normalize(vNormal), vec3(0.0, 0.0, 1.0));
+          vec3 base = mix(vec3(0.2, 0.8, 1.0), vec3(1.0, 0.2, 0.4), uLevel);
+          gl_FragColor = vec4(base * intensity, 1.0);
+        }
+      `,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    const audioCtx = new AudioCtx();
+    const analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    const data = new Uint8Array(analyser.frequencyBinCount);
+
+    let cleanup = false;
+
+    navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+      if (cleanup) return;
+      const source = audioCtx.createMediaStreamSource(stream);
+      source.connect(analyser);
+
+      const animate = () => {
+        if (cleanup) return;
+        requestAnimationFrame(animate);
+        analyser.getByteFrequencyData(data);
+        const level = data.reduce((a, b) => a + b, 0) / data.length / 255;
+        material.uniforms.uLevel.value = level;
+        material.uniforms.uTime.value = performance.now() / 1000;
+        mesh.rotation.y += 0.01;
+        renderer.render(scene, camera);
+      };
+      animate();
+    });
+
+    return () => {
+      cleanup = true;
+    };
+  }, []);
+
+  return (
+    <>
+      <div style={{ position: "absolute", top: 16, left: 16 }}>
+        <Link to="/circle" style={{ color: "#646cff" }}>Circle</Link>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          background: "#000",
+        }}
+      >
+        <canvas ref={canvasRef} style={{ width: 200, height: 200 }} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add React Router and Three.js dependencies
- replace standalone HTML with Circle and voice-reactive pages inside SPA
- implement 200x200 Three.js shader sphere driven by mic FFT

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Cannot find module 'react-router-dom' or 'three')

------
https://chatgpt.com/codex/tasks/task_e_6895fc33c934832ba0b5de33398bfc2a